### PR TITLE
Fix #32 : Limit the blog post title length to 3 rows ~90 characters

### DIFF
--- a/angular-material-app/src/app/components/posts/posts.component.html
+++ b/angular-material-app/src/app/components/posts/posts.component.html
@@ -7,7 +7,7 @@
           <img [src]="post.coverImage.url">
         </div>
         <div class="card-title">
-          <h3>{{post.title}}</h3>
+          <h3>{{ truncateTitle(post.title) }}</h3>
         </div>
       </a>
     </mat-card>

--- a/angular-material-app/src/app/components/posts/posts.component.html
+++ b/angular-material-app/src/app/components/posts/posts.component.html
@@ -7,7 +7,7 @@
           <img [src]="post.coverImage.url">
         </div>
         <div class="card-title">
-          <h3>{{ truncateTitle(post.title) }}</h3>
+          <h3>{{ post.title.length > 90 ? (post.title | slice:0:90) + '...' : (post.title) }}</h3>
         </div>
       </a>
     </mat-card>

--- a/angular-material-app/src/app/components/posts/posts.component.ts
+++ b/angular-material-app/src/app/components/posts/posts.component.ts
@@ -55,4 +55,12 @@ export class PostsComponent implements OnInit {
 	navigateToPost(slug: string) {
 		this.router.navigate(["/post", slug]);
 	}
+
+	truncateTitle(title: string): string {
+		const maxLength = 90;
+		if (title.length > maxLength) {
+		  return title.substring(0, maxLength - 3) + "...";
+		}
+		return title;
+	}
 }

--- a/angular-material-app/src/app/components/posts/posts.component.ts
+++ b/angular-material-app/src/app/components/posts/posts.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, inject } from "@angular/core";
 import { BlogService } from "../../services/blog.service";
 import { Router, RouterLink } from "@angular/router";
-import { AsyncPipe } from "@angular/common";
+import { AsyncPipe, SlicePipe } from "@angular/common";
 import { BreakpointObserver, Breakpoints } from "@angular/cdk/layout";
 import { map } from "rxjs/operators";
 import { MatGridListModule } from "@angular/material/grid-list";
@@ -12,7 +12,7 @@ import { Post } from "../../models/post";
 @Component({
 	selector: "app-posts",
 	standalone: true,
-	imports: [RouterLink, MatCardModule, MatGridListModule, AsyncPipe],
+	imports: [RouterLink, MatCardModule, MatGridListModule, AsyncPipe, SlicePipe],
 	templateUrl: "./posts.component.html",
 	styleUrl: "./posts.component.scss",
 })
@@ -54,13 +54,5 @@ export class PostsComponent implements OnInit {
 
 	navigateToPost(slug: string) {
 		this.router.navigate(["/post", slug]);
-	}
-
-	truncateTitle(title: string): string {
-		const maxLength = 90;
-		if (title.length > maxLength) {
-		  return title.substring(0, maxLength - 3) + "...";
-		}
-		return title;
 	}
 }

--- a/angular-material-app/src/app/components/series/series.component.html
+++ b/angular-material-app/src/app/components/series/series.component.html
@@ -7,7 +7,7 @@
           <img [src]="post.coverImage.url">
         </div>
         <div class="card-title">
-          <h3>{{post.title}}</h3>
+          <h3>{{ post.title.length > 90 ? (post.title | slice:0:90) + '...' : (post.title) }}</h3>
         </div>
       </a>
     </mat-card>

--- a/angular-material-app/src/app/components/series/series.component.ts
+++ b/angular-material-app/src/app/components/series/series.component.ts
@@ -3,14 +3,14 @@ import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { Observable, switchMap } from 'rxjs';
 import { Post } from '../../models/post';
 import { BlogService } from '../../services/blog.service';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, SlicePipe } from '@angular/common';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCardModule } from '@angular/material/card';
 
 @Component({
   selector: 'app-series',
   standalone: true,
-  imports: [RouterLink, AsyncPipe, MatGridListModule, MatCardModule],
+  imports: [RouterLink, AsyncPipe, MatGridListModule, MatCardModule, SlicePipe],
   templateUrl: './series.component.html',
   styleUrl: './series.component.scss'
 })

--- a/angular-material-app/src/app/components/series/series.component.ts
+++ b/angular-material-app/src/app/components/series/series.component.ts
@@ -1,4 +1,3 @@
-
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { Observable, switchMap } from 'rxjs';


### PR DESCRIPTION
## This PR Closes Issue 
closes #32

## Description
Hello,
As it was requested in issue #32, I have implemented the code changes that would check if the total length of title exceeds 90 characters or not.
If it does, then the later part would be truncated with 3 dots (...) at the end.
If it doesn't, then the title would be displayed as it is.
If at all there is something that I missed, then do let let me know.
Sincere apologies for my mistakes if you find any.

## What type of PR is this? (check all applicable)

- [ ] 🅰️ Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
![image](https://github.com/AnguHashBlog/angular-material/assets/31406633/5c1ea811-ab1c-49d2-8b07-c6ccf0231507)

## Steps to QA
Run the server and check the posts tiles.

## Added to documentation?
- [ ] 📜 README.md
- [X] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
