### PR TITLE
feat(routing): the 'post' part is removed from post details path

### DIFF
--- a/angular-material-app/src/app/app.routes.ts
+++ b/angular-material-app/src/app/app.routes.ts
@@ -21,7 +21,7 @@ export const routes: Routes = [
     ]
   },
   {
-    path: 'post/:slug',
+    path: ':slug',
     component: PostDetailsComponent
   }
 ];

--- a/angular-material-app/src/app/components/header/header.component.html
+++ b/angular-material-app/src/app/components/header/header.component.html
@@ -25,7 +25,7 @@
   <mat-toolbar-row>
     <div class="series">
       @for (series of seriesList; track series) {
-      <a [routerLink]="'series/' + series.slug" class="series-link">{{ series.name }}</a>
+      <a [routerLink]="['series/', series.slug]" class="series-link">{{ series.name }}</a>
       }
     </div>
   </mat-toolbar-row>

--- a/angular-material-app/src/app/components/posts/posts.component.html
+++ b/angular-material-app/src/app/components/posts/posts.component.html
@@ -2,7 +2,7 @@
   <div class="cards-wrapper grid">
     @for (post of posts$ | async; track post) {
       <mat-card>
-      <a [routerLink]="['post', post.slug]">
+      <a [routerLink]="[post.slug]">
         <div class="card-image">
           <img [src]="post.coverImage.url">
         </div>

--- a/angular-material-app/src/app/components/posts/posts.component.ts
+++ b/angular-material-app/src/app/components/posts/posts.component.ts
@@ -15,12 +15,12 @@ import { Post } from "../../models/post";
 	styleUrl: "./posts.component.scss",
 })
 export class PostsComponent implements OnInit {
-  blogURL!: string;
-  posts$!: Observable<Post[]>;
+	blogURL!: string;
+	posts$!: Observable<Post[]>;
 	private blogService = inject(BlogService);
 
 	ngOnInit() {
-    this.blogURL = this.blogService.getBlogURL();
+		this.blogURL = this.blogService.getBlogURL();
 		this.posts$ = this.blogService.getPosts(this.blogURL);
 	}
 }

--- a/angular-material-app/src/app/components/series/series.component.html
+++ b/angular-material-app/src/app/components/series/series.component.html
@@ -2,7 +2,7 @@
   <div class="cards-wrapper grid">
     @for (post of postsInSeries$ | async; track post) {
       <mat-card>
-      <a [routerLink]="['/post', post.slug]">
+      <a [routerLink]="['/', post.slug]">
         <div class="card-image">
           <img [src]="post.coverImage.url">
         </div>


### PR DESCRIPTION
## This PR Closes Issue 
closes #42 

## Description
- Routing - remove `post` from the post-details path in app.routes.ts

## What type of PR is this? (check all applicable)

- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
